### PR TITLE
feat(tokenizer): add file processing capabilities

### DIFF
--- a/src/txt_to_anki/tokenizer/__init__.py
+++ b/src/txt_to_anki/tokenizer/__init__.py
@@ -9,5 +9,17 @@ from __future__ import annotations
 
 from txt_to_anki.tokenizer.token_models import Token
 from txt_to_anki.tokenizer.japanese_tokenizer import JapaneseTokenizer, TokenizationMode
+from txt_to_anki.tokenizer.exceptions import (
+    FileProcessingError,
+    TokenizationError,
+    TokenizerInitializationError,
+)
 
-__all__ = ["Token", "JapaneseTokenizer", "TokenizationMode"]
+__all__ = [
+    "Token",
+    "JapaneseTokenizer",
+    "TokenizationMode",
+    "FileProcessingError",
+    "TokenizationError",
+    "TokenizerInitializationError",
+]


### PR DESCRIPTION
## Description
Implements file processing capabilities for the JapaneseTokenizer class, enabling direct tokenization of Japanese text files.

## Related Issue
Closes #4

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Type hints added (mypy passes) ✅ REQUIRED
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (docstrings)
- [x] Tests added/updated (9 new tests)
- [x] All tests passing (24/24 tests pass)
- [x] No new warnings

## Testing
Added comprehensive test suite covering:
- File reading with Path objects and string paths
- UTF-8 encoding validation
- Error handling for:
  - Non-existent files
  - Directory paths
  - Empty files
  - Whitespace-only files
  - Invalid encoding (non-UTF-8)
  - Permission errors
- Multi-line text processing
- Real Japanese text file processing

All tests pass with 78% code coverage.

## Implementation Details
- Added `tokenize_file` method to `JapaneseTokenizer` class
- Accepts both `Path` objects and string paths
- Validates file existence and type
- Reads files with UTF-8 encoding validation
- Provides helpful, actionable error messages
- Reuses existing `tokenize_text` method for tokenization
- Exported `FileProcessingError` from tokenizer module

## Quality Checks
```bash
✅ poetry run mypy src/        # Success: no issues found
✅ poetry run black .          # All done! ✨ 🍰 ✨
✅ poetry run ruff check .     # No issues
✅ poetry run pytest           # 24 passed in 0.74s
```
